### PR TITLE
Removed properties not yet being used from include_properties_list.csv

### DIFF
--- a/wikidata-lists/include_properties_list.csv
+++ b/wikidata-lists/include_properties_list.csv
@@ -1,148 +1,14 @@
 property id	label
-P1006	Nationale Thesaurus voor Auteursnamen ID
-P101	field of work
-P1015	NORAF ID
-P102	member of political party
 P1038	relative
-P10553	IxTheo authority ID
-P106	occupation
-P1066	student of
 P108	employer
-P10832	WorldCat Entities ID
-P11249	KBR person ID
-P11271	African American Visual Artists Database ID
-P11496	CiNii Research ID
-P11870	The Literary Encyclopedia person ID
-P119	place of burial
-P1196	manner of death
-P1207	NUKAT ID
-P1225	U.S. National Archives Identifier
-P1233	Internet Speculative Fiction Database author ID
-P12458	Parsifal cluster ID
-P12582	Oxford Reference overview ID
-P1263	NNDB people ID
-P1280	CONOR.SI ID
-P1284	Munzinger person ID
-P1303	instrument
-P1315	NLA Trove people ID
-P1343	described by source
-P1344	participant in
-P140	religion or worldview
-P1412	languages spoken, written or signed
-P1415	Oxford Dictionary of National Biography ID
-P1417	Encyclopædia Britannica Online ID
-P1442	image of grave
-P1477	birth name
-P1556	zbMATH author ID
-P1559	name in native language
-P1563	MacTutor biography ID
-P166	award received
-P1695	NLP ID (old)
-P172	ethnic group
 P18	image
-P1816	National Portrait Gallery (London) person ID
-P184	doctoral advisor
-P1871	CERL Thesaurus ID
-P1899	LibriVox author ID
 P19	place of birth
-P1935	Database of Classical Scholars ID
-P1938	Project Gutenberg author ID
-P195	collection
-P1971	number of children
-P20	place of death
-P2031	work period (start)
 P21	sex or gender
-P213	ISNI
-P214	VIAF ID
-P2163	FAST ID
-P217	inventory number
 P22	father
-P227	GND ID
-P244	Library of Congress authority ID
 P26	spouse
-P2600	Geni.com profile ID
-P2671	Google Knowledge Graph ID
-P268	Bibliothèque nationale de France ID
-P269	IdRef ID
-P27	country of citizenship
-P271	NACSIS-CAT author ID
-P2734	Unz Review author ID
-P2889	FamilySearch person ID
-P2930	INSPIRE-HEP author ID
-P2949	WikiTree person ID
-P2963	Goodreads author ID
-P3029	UK National Archives ID
-P3065	RERO ID (obsolete)
-P31	instance of
-P3123	Stanford Encyclopedia of Philosophy ID
-P3368	Prabook ID
 P3373	sibling
-P3417	Quora topic ID
-P3430	SNAC ARK ID
-P3716	social classification
-P373	Commons category
-P3762	openMLOL author ID
-P39	position held
-P3987	SHARE Catalogue author ID
-P40	child
-P4081	BHL creator ID
-P409	Libraries Australia ID
-P4104	Carnegie Hall agent ID
-P434	MusicBrainz artist ID
-P4629	Online Books Page author ID
-P463	member of
-P4823	American National Biography ID
 P485	archives at
-P4903	New Georgia Encyclopedia ID
-P4955	MR Author ID
-P5008	on focus list of Wikimedia project
-P5034	National Library of Korea ID
-P509	cause of death
-P535	Find a Grave memorial ID
-P5361	BNB person ID
-P549	Mathematics Genealogy Project ID
 P551	residence
-P5587	Libris-URI
 P569	date of birth
 P570	date of death
-P5739	Pontificia Università della Santa Croce ID
-P6104	maintained by WikiProject
-P625	coordinate location
-P6284	NCpedia ID
-P6371	Archives of Maryland Biographical Series ID
-P646	Freebase ID
-P648	Open Library ID
-P6594	Guggenheim fellows ID
-P6722	FemBio ID
-P6723	BlackPast.org ID
-P6886	writing language
 P69	educated at
-P691	NL CR AUT ID
-P6925	Musicalics composer ID
-P701	Dodis ID
-P723	Digitale Bibliotheek voor de Nederlandse Letteren author ID
-P7293	PLWABN ID
-P734	family name
-P735	given name
-P7444	Rijksmuseum Research Library authority ID
-P7685	CALS Encyclopedia of Arkansas ID
-P7690	South Carolina Encyclopedia ID
-P7699	National Library of Lithuania ID
-P7704	Europeana entity
-P7902	Deutsche Biographie (GND) ID
-P8017	generational suffix
-P8081	WBIS ID
-P8085	Curran Index contributor ID
-P8189	National Library of Israel J9U ID
-P8349	Proleksis enciklopedija ID
-P8462	Political Graveyard politician ID
-P8591	Grove Music Online ID
-P863	InPhO ID
-P8896	Concise Literary Encyclopedia ID
-P8902	Archives at Yale agent ID
-P8947	Museo Galileo authority ID
-P906	SELIBR ID
-P937	work location
-P949	National Library of Israel ID (old)
-P950	National Library of Spain ID
-P973	described at URL


### PR DESCRIPTION
Removed properties from this list that we are not currently adding to new Wikidata records. There will likely be some properties to add to this list that have not yet appeared in our test set (e.g., we have "father" here but not "mother" and may use "notable works" for publications).