### PR TITLE
Update include_properties_list.csv

### DIFF
--- a/wikidata-lists/include_properties_list.csv
+++ b/wikidata-lists/include_properties_list.csv
@@ -7,7 +7,6 @@ P22	father
 P25	mother
 P26	spouse
 P3373	sibling
-P485	archives at
 P53	family
 P551	residence
 P569	date of birth


### PR DESCRIPTION
Removed the "archives at" property as it only applies to a couple people and is displaying as "Is Referenced By" in Omeka.